### PR TITLE
Update services.yml

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -5,4 +5,4 @@ services:
     fungio.dataexporter:
         class: %fungio.dataexporter.class%
         public: true
-        scope: prototype
+        shared: false


### PR DESCRIPTION
``` sh
The configuration key "scope" is unsupported for service definition "fungio.dataexporter" in "services.yml". Allowed configuration keys are "alias", "parent", "class", "shared", "synthetic", "lazy", "public", "abstract", "deprecated", "factory", "file", "arguments", "properties", "configurator", "calls", "tags", "decorates", "decoration_inner_name", "decoration_priority", "autowire", "autowiring_types". The YamlFileLoader object will raise an exception instead in Symfony 4.0 when detecting an unsupported service configuration key: 1x
    1x in DefaultControllerTest::testIndex from Tests\AppBundle\Controller
```

http://symfony.com/blog/new-in-symfony-2-8-deprecating-scopes-and-introducing-shared-services
