### PR TITLE
fixed not qouting the scalar

### DIFF
--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -3,6 +3,6 @@ parameters:
 
 services:
     fungio.dataexporter:
-        class: %fungio.dataexporter.class%
+        class: "%fungio.dataexporter.class%"
         public: true
         shared: false


### PR DESCRIPTION
"Not quoting the scalar "%fungio.dataexporter.class%" starting with the "%" indicator character is deprecated since Symfony 3.1 and will throw a ParseException in 4.0: 1x"
